### PR TITLE
Table-like styles

### DIFF
--- a/doc/app.md
+++ b/doc/app.md
@@ -2,5 +2,6 @@
 
 All settings and message strings are defined in `conf/`
 
-You can override them by copying `*.default.yaml` to `*.local.yaml` and adjusting the values.
+You can override the defaults by copying `settings.default.yaml` and/or `language.default.yaml` to `*.local.yaml` and adjusting the values.
 
+**Note:** as there is no translation mechanism yet, the provided German language file `language-de.default.yaml` is just an example and needs to be copied manually to `language.local.yaml`, as described above.

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11,10 +11,6 @@ canvas {
     background: #ffffff;
 }
 
-.fieldset-label {
-    font-size: 20pt;
-}
-
 .checkbox {
     padding-left: 4px;
     padding-right: 4px;
@@ -24,8 +20,136 @@ canvas {
     display: none;
 }
 
-/** Required so fieldsets dont destroy bulmas column system */
+/** Required so fieldsets don't destroy Bulma's column system */
 fieldset {
     display: contents;
+}
 
+.fieldset-label {
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.is-full .fieldset-label {
+    margin-bottom: 1rem;
+}
+
+fieldset h3,
+fieldset .subtitle {
+    font-size: 1.13rem;
+    font-weight: 400;
+    line-height: 1.25;
+}
+
+
+/** + + + + +  spacer  + + + + + */
+.field.is-spacer {
+    height: 5rem;
+}
+
+.field.is-spacer-doublelabel {
+    height: 6.5rem;
+}
+
+
+@media screen and (min-width: 769px), print {
+    .fieldset-label {
+        min-height: 3.75rem;
+    }
+
+    .is-full .fieldset-label {
+        min-height: 1rem;
+    }
+
+    .columns.is-multiline {
+        margin-bottom: 1rem;
+    }
+
+    .columns.is-multiline .is-multiline {
+        margin-bottom: 0;
+    }
+
+    .is-left-label .field.is-spacer {
+        height: 3rem;
+    }
+
+
+    /** + + + + +  label once  + + + + + */
+
+    /* + + +  width of cols  + + + */
+
+    .is-left-label .column.is-half {
+        width: 33.3333%;
+    }
+
+    .is-left-label fieldset:first-of-type .column.is-half {
+        width: 66.6666%;
+    }
+
+    .is-left-label .column.is-one-third {
+        width: 25%;
+    }
+
+    .is-left-label fieldset:first-of-type .column.is-one-third {
+        width: 50%;
+    }
+
+    .is-left-label .column.is-one-quarter {
+        width: 20%;
+    }
+
+    .is-left-label fieldset:first-of-type .column.is-one-quarter {
+        width: 40%;
+    }
+
+    /* + + +  background of cols  + + + */
+
+    .is-left-label fieldset:nth-of-type(even) .column .is-multiline {
+        background-color: #F3F3F3;
+    }
+
+    .is-left-label fieldset:first-of-type .fieldset-content .columns {
+        position: relative;
+    }
+
+    .is-left-label fieldset:first-of-type .fieldset-content .columns::before {
+        content: '';
+        position: absolute;
+        width: 50%;
+        height: 100%;
+        background-color: #F3F3F3;
+        border-right: 10px solid #FFFFFF;
+    }
+
+    /* + + +  position of col header (1. col)  + + + */
+
+    .is-left-label fieldset:first-of-type .fieldset-label {
+        width: 50%;
+        margin-right: 0;
+        margin-left: auto;
+    }
+
+    /* + + +  position of labels + width of input (1. col)  + + + */
+
+    .is-left-label .column .field {
+        position: relative;
+    }
+
+    .is-left-label label {
+        position: absolute;
+        left: -1000rem;
+        top: -1000rem;
+    }
+
+    .is-left-label fieldset:first-of-type label {
+        left: 0;
+        top: 0;
+        width: 50%;
+    }
+
+    .is-left-label fieldset:first-of-type .control {
+        width: 50%;
+        margin-right: 0;
+        margin-left: auto;
+    }
 }

--- a/src/FormGenerator/FormElementFactory.php
+++ b/src/FormGenerator/FormElementFactory.php
@@ -18,6 +18,7 @@ use CosmoCode\Formserver\FormGenerator\FormElements\MarkDownFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\NumberInputFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\RadiosetFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\SignatureFormElement;
+use CosmoCode\Formserver\FormGenerator\FormElements\SpacerFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\TextAreaFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\TextInputFormElement;
 use CosmoCode\Formserver\FormGenerator\FormElements\TimeFormElement;
@@ -79,6 +80,8 @@ class FormElementFactory
                 return new DropdownFormElement($id, $config, $parent);
             case 'signature':
                 return new SignatureFormElement($id, $config, $parent);
+            case 'spacer':
+                return new SpacerFormElement($id, $config, $parent);
             default:
                 throw new FormException(
                     "Could not build FormElement id:$id. Undefined type ($formType)"

--- a/src/FormGenerator/FormElements/SpacerFormElement.php
+++ b/src/FormGenerator/FormElements/SpacerFormElement.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CosmoCode\Formserver\FormGenerator\FormElements;
+
+/**
+ * Spacer element to better control table-like layouts
+ */
+class SpacerFormElement extends AbstractDynamicFormElement
+{
+}

--- a/view/fieldset.twig
+++ b/view/fieldset.twig
@@ -1,6 +1,7 @@
 {% from '_macros' import renderError %}
 
-<fieldset {{ toggle is not empty ? ('data-toggle-id="'~toggle.id~'" data-toggle-value="'~toggle.value~'"') | raw }}>
+<fieldset {{ toggle is not empty ? ('data-toggle-id="'~toggle.id~'" data-toggle-value="'~toggle.value~'"') | raw }}
+        {% if tablestyle is not empty %} class="is-left-label"{% endif %}>
     <legend class="hidden">{{ label }}</legend>
     <div class="column {{ column is not empty ? column : 'is-full' }} fieldset-content">
         <div class="label fieldset-label">
@@ -12,8 +13,4 @@
             {% endfor %}
         </div>
     </div>
-
-
 </fieldset>
-
-

--- a/view/spacer.twig
+++ b/view/spacer.twig
@@ -1,0 +1,5 @@
+<div class="column {{ column is not empty ? column : 'is-full' }}">
+    <div class="field is-spacer{{ double is not empty ? '-doublelabel' : '' }}">
+        <label class="label">{{ label }}</label>
+    </div>
+</div>


### PR DESCRIPTION
YAD-22: Reduce visual clutter by styling fieldsets with columns to look like tables.

There is also a new static element `spacer` to separate fields in table-like fieldsets.