### PR TITLE
Add 'scrollable' attribute to fieldsets

### DIFF
--- a/doc/formelements.md
+++ b/doc/formelements.md
@@ -22,6 +22,7 @@ Fieldsets group other form elements (including nested fieldsets).
 Options:
 * `children` _(required)_ - containing child form elements
 * `tablestyle` _(optional)_ set table view true or false. This will color the rows like zebrastripes. Labels of the containing formElements are hidden. The tablehead row will be populated from the labels from the children of the first fieldset. If cells in the first row must be skipped then [Spacers](#Spacer) can be used.
+* `scrollable` _(optional)_ can be used with `tablestyle`: The fieldset will not responsively adapt to screen width, but will extend horizontally and can be scrolled. The option may have unpredictable effects in complex forms!
 * `toggle` _(optional)_ - the fieldset is disabled and hidden until the toggle condition is met
   * `field` - dotted path to the field whose value will be evaluated to match the toggle condition
   * `value` - required value to toggle the fieldset on

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -182,3 +182,21 @@ fieldset .subtitle {
         margin-left: auto;
     }
 }
+
+.is-scrollable {
+    width: 100%;
+    overflow-y: auto;
+    margin: 0 0 1em;
+}
+
+.is-scrollable::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+}
+
+.is-scrollable::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    border: 3px solid #fff;
+    background-color: rgba(0, 0, 0, .3);
+}

--- a/view/fieldset.twig
+++ b/view/fieldset.twig
@@ -1,5 +1,6 @@
 {% from '_macros' import renderError %}
 
+{% if scrollable is not empty %}<div class="is-scrollable">{% endif %}
 <fieldset {{ toggle is not empty ? ('data-toggle-id="'~toggle.id~'" data-toggle-value="'~toggle.value~'"') | raw }}
         {% if tablestyle is not empty %} class="is-left-label"{% endif %}>
     <legend class="hidden">{{ label }}</legend>
@@ -7,10 +8,12 @@
         <div class="label fieldset-label">
             {{ label }}
         </div>
-        <div class="columns is-multiline">
+        <div class="columns{% if scrollable is empty %} is-multiline{% endif %}">
+            {% if tablestyle is not empty %}<div class="next-is-double"></div>{% endif %}
             {% for rendered_child_view in rendered_child_views %}
                 {{ rendered_child_view | raw }}
             {% endfor %}
         </div>
     </div>
 </fieldset>
+    {% if scrollable is not empty %}</div>{% endif %}


### PR DESCRIPTION
This attribute may sometimes make sense in combination with
'tablestyle', so that columns will overflow instead of fitting
the screen width responsively.