### PR TITLE
Dynamically double the width of table column with labels

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -174,3 +174,25 @@ function clearFormElementValue(formInput) {
         formInput.value = '';
     }
 }
+
+/*
+ * Table-like style
+ * Double the width of the first column to fit both labels and input fields
+ */
+Array.from(document.querySelectorAll('.is-left-label .next-is-double')).forEach(function(elem) {
+    colThird = elem.nextElementSibling.querySelector('.is-one-third');
+    if (colThird) {
+        colThird.classList.remove('is-one-third');
+        colThird.classList.add('is-two-thirds');
+    }
+    colQuarter = elem.nextElementSibling.querySelector('.is-one-quarter');
+    if (colQuarter) {
+        colQuarter.classList.remove('is-one-quarter');
+        colQuarter.classList.add('is-two-quarters');
+    }
+    colFifth = elem.nextElementSibling.querySelector('.is-one-fifth');
+    if (colFifth) {
+        colFifth.classList.remove('is-one-fifth');
+        colFifth.classList.add('is-two-fifths');
+    }
+});


### PR DESCRIPTION
The first column in table-like fieldsets must fit labels and inputs. We double its width so that the inputs are as wide as those in other columns (with hidden lables).