### PR TITLE
Multiuser forms when save button is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Form server
 
-This is a PHP app that generates HTML forms from YAML descriptions. It will save and optionally email the submitted data.
+This is a PHP app that generates HTML forms from YAML descriptions.
 
-The goal is to gather user-specific data. The initial submissions may be incomplete and can be updated at a later time without the need for additional authentication mechanisms or databases.
+It can save and/or email the submitted data.
+
+## Use cases
+
+### Save data
+
+This is the default behavior of the app. The goal is to gather user-specific data. The initial submissions may be incomplete and can be updated at a later time without the need for additional authentication mechanisms or databases.
 
 Each form is accessed via a direct link, which contains the form ID (form directory).
+
+### Do not persist, only send
+
+If the save button is disabled in [form configuration](doc/meta.md), no data is persisted. Each submission  is completely independent of each other. Multiple users can safely access the same form.
 
 ## Usage
 
@@ -24,7 +34,6 @@ The [reference](doc/index.md) details all available options. A demo form is prov
 ## Current limitations
 
  * The YAML files are not validated. You will see no warnings if your configuration cannot be translated into an HTML form.
- * There is no user management or reusing the same form for multiple users.
 
 ## Install
 

--- a/doc/meta.md
+++ b/doc/meta.md
@@ -56,14 +56,15 @@ When the form email gets send the given file (in this case file_to_be_moved.txt)
  
  The directory is always relative to the project's root directory.
  
- ## Visibility of the "Save" button
+ ## "Save" button
  
  ```yaml
    saveButton: false
  ```
  
-The visibilty of the save button can be toggled.
-If this option is not set the button will be shown by default.
+This option disables not only the save button, but also persisting user inputs. **As soon as the form is successfully submitted, all data is lost, so send it per email!**
+
+This way you can re-use the same form for multiple submissions of different data or for multiple users.
 
 ## Tooltips
 

--- a/src/Actions/FormAction.php
+++ b/src/Actions/FormAction.php
@@ -71,6 +71,11 @@ class FormAction extends AbstractAction
                 if ($form->isValid() && $form->getMode() === Form::MODE_SEND) {
                     $this->mailer->sendForm($form);
                     $this->handleFileExport($form);
+                    // finally clean up if it is a non-persistent form
+                    if ($form->getMeta('saveButton') === false) {
+                        $formElements = $form->getFormElements();
+                        $form->reset($formElements);
+                    }
                 }
             } elseif ($this->request->getMethod() === 'GET') {
                 $form->restore();

--- a/src/Actions/FormAction.php
+++ b/src/Actions/FormAction.php
@@ -66,7 +66,10 @@ class FormAction extends AbstractAction
                     $this->request->getUploadedFiles()
                 );
                 $formValidator->validate();
-                $form->getMeta('saveButton') !== false && $form->persist();
+
+                if ($form->getMeta('saveButton') !== false) {
+                    $form->persist();
+                }
 
                 if ($form->isValid() && $form->getMode() === Form::MODE_SEND) {
                     $this->mailer->sendForm($form);

--- a/src/Actions/FormAction.php
+++ b/src/Actions/FormAction.php
@@ -66,7 +66,7 @@ class FormAction extends AbstractAction
                     $this->request->getUploadedFiles()
                 );
                 $formValidator->validate();
-                $form->persist();
+                $form->getMeta('saveButton') !== false && $form->persist();
 
                 if ($form->isValid() && $form->getMode() === Form::MODE_SEND) {
                     $this->mailer->sendForm($form);

--- a/src/FormGenerator/Form.php
+++ b/src/FormGenerator/Form.php
@@ -157,12 +157,6 @@ class Form
      */
     public function submit(array $data, array $files)
     {
-        // Important! Restore persisted data first to determine if UploadFormElements
-        // have already an uploaded file (They have a value which contains the file
-        // name)
-        // FIXME is this still necessary?
-        $this->restore();
-
         // submit data
         foreach ($this->formElements as $formElement) {
             $this->submitFormElement($formElement, $data, $files);
@@ -439,8 +433,11 @@ class Form
                 $this->setDefaultValues($fieldsetChild);
             }
         } elseif ($formElement instanceof ChecklistFormElement
-            || $formElement instanceof  DropdownFormElement) {
-            $formElement->setDefaultValue();
+            || $formElement instanceof  DropdownFormElement
+        ) {
+            if (! $formElement->hasValue()) {
+                $formElement->setDefaultValue();
+            }
         }
     }
 

--- a/src/FormGenerator/Form.php
+++ b/src/FormGenerator/Form.php
@@ -249,7 +249,7 @@ class Form
                 $childElements = $formElement->getChildren();
                 $this->reset($childElements);
             } else {
-                $formElement->clearValue();
+                $formElement->clearValue($this->getFormDirectory());
             }
         }
 

--- a/src/FormGenerator/FormElements/AbstractDynamicFormElement.php
+++ b/src/FormGenerator/FormElements/AbstractDynamicFormElement.php
@@ -65,7 +65,10 @@ abstract class AbstractDynamicFormElement extends AbstractFormElement
         }
     }
 
-    public function clearValue()
+    /**
+     * @param string $formPath
+     */
+    public function clearValue(string $formPath)
     {
         $this->value = null;
     }

--- a/src/FormGenerator/FormElements/AbstractDynamicFormElement.php
+++ b/src/FormGenerator/FormElements/AbstractDynamicFormElement.php
@@ -65,6 +65,11 @@ abstract class AbstractDynamicFormElement extends AbstractFormElement
         }
     }
 
+    public function clearValue()
+    {
+        $this->value = null;
+    }
+
     /**
      * Returns the field's configured validation rules
      *

--- a/src/FormGenerator/FormElements/ChecklistFormElement.php
+++ b/src/FormGenerator/FormElements/ChecklistFormElement.php
@@ -17,6 +17,11 @@ class ChecklistFormElement extends AbstractDynamicFormElement
      */
     public function setDefaultValue()
     {
+
+        if ($this->getValue()) {
+            return;
+        }
+
         $defaultValue = $this->getConfigValue('default');
 
         if ($defaultValue) {

--- a/src/FormGenerator/FormElements/ChecklistFormElement.php
+++ b/src/FormGenerator/FormElements/ChecklistFormElement.php
@@ -18,10 +18,6 @@ class ChecklistFormElement extends AbstractDynamicFormElement
     public function setDefaultValue()
     {
 
-        if ($this->getValue()) {
-            return;
-        }
-
         $defaultValue = $this->getConfigValue('default');
 
         if ($defaultValue) {

--- a/src/FormGenerator/FormElements/DropdownFormElement.php
+++ b/src/FormGenerator/FormElements/DropdownFormElement.php
@@ -15,6 +15,10 @@ class DropdownFormElement extends AbstractDynamicFormElement
      */
     public function setdefaultvalue()
     {
+        if ($this->getValue()) {
+            return;
+        }
+
         $defaultValue = $this->getConfigValue('default');
 
         if ($defaultValue) {

--- a/src/FormGenerator/FormElements/DropdownFormElement.php
+++ b/src/FormGenerator/FormElements/DropdownFormElement.php
@@ -13,7 +13,7 @@ class DropdownFormElement extends AbstractDynamicFormElement
      *
      * @return void
      */
-    public function setdefaultvalue()
+    public function setDefaultValue()
     {
         if ($this->getValue()) {
             return;

--- a/src/FormGenerator/FormElements/UploadFormElement.php
+++ b/src/FormGenerator/FormElements/UploadFormElement.php
@@ -38,12 +38,12 @@ class UploadFormElement extends AbstractDynamicFormElement
      *
      * @param $formPath
      */
-    public function setDefaultValue($formPath)
+    public function clearValue($formPath)
     {
         if ($this->value && is_file($formPath . $this->value)) {
             unlink($formPath . $this->value);
-            unset($this->value);
         }
+        $this->setValue(null);
     }
 
     /**

--- a/src/FormGenerator/FormElements/UploadFormElement.php
+++ b/src/FormGenerator/FormElements/UploadFormElement.php
@@ -12,6 +12,17 @@ class UploadFormElement extends AbstractDynamicFormElement
      */
     protected $previousValue = '';
 
+    /**
+     * Update previous value on every upload
+     *
+     * @param mixed $value
+     */
+    public function setValue($value)
+    {
+        parent::setValue($value);
+        $this->setPreviousValue($value);
+    }
+
     public function getPreviousValue()
     {
         return $this->previousValue;

--- a/src/FormGenerator/FormElements/UploadFormElement.php
+++ b/src/FormGenerator/FormElements/UploadFormElement.php
@@ -7,6 +7,33 @@ namespace CosmoCode\Formserver\FormGenerator\FormElements;
  */
 class UploadFormElement extends AbstractDynamicFormElement
 {
+    /**
+     * @var string
+     */
+    protected $previousValue = '';
+
+    public function getPreviousValue()
+    {
+        return $this->previousValue;
+    }
+
+    public function setPreviousValue($value)
+    {
+        $this->previousValue = $value;
+    }
+
+    /**
+     * Remove old file before resetting the value, useful when clearing the form after submit
+     *
+     * @param $formPath
+     */
+    public function setDefaultValue($formPath)
+    {
+        if ($this->value && is_file($formPath . $this->value)) {
+            unlink($formPath . $this->value);
+            unset($this->value);
+        }
+    }
 
     /**
      * Get allowed extension for this upload
@@ -49,6 +76,7 @@ class UploadFormElement extends AbstractDynamicFormElement
                 'errors' => $this->getErrors(),
                 'allowed_extensions' => $this->getAllowedExtensionsAsArray(),
                 'value' => $this->getValue(),
+                'previous_value' => $this->getPreviousValue(),
                 'is_required' => $this->isRequired()
             ]
         );

--- a/view/upload.twig
+++ b/view/upload.twig
@@ -13,6 +13,9 @@
                        name="{{ id }}"
                        {{ allowed_extensions is defined ? ('accept=".'~allowed_extensions|join(',.')~'"')|raw }}
                        data-info-container-id="{{ id }}-upload-info" />
+                <input type="hidden"
+                       name="{{ id }}[previous_value]"
+                       value="{{ previous_value }}">
                 <span class="file-cta">
                     <span class="file-label">
                         {{ is_uploaded ? button_upload_replace : button_upload_label }}


### PR DESCRIPTION
When the save button is disabled, no data is persisted. This makes the form usable for multiple submissions of unrelated data, or by multiple users.

Previously the setting `saveButton: false` only hid the button in the rendered form.